### PR TITLE
Add --wait arg for open_mower roslaunchto wait for the roscore container

### DIFF
--- a/docker/openmower/scripts/start_mowgli.sh
+++ b/docker/openmower/scripts/start_mowgli.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Starting OpenMower"
 source /config/mower_config.sh
-roslaunch open_mower open_mower.launch
+roslaunch --wait open_mower open_mower.launch


### PR DESCRIPTION
And avoid to launch a second roscore if started before the roscore container.