### PR TITLE
Fix amd64 vs arm64 artifact name uniqueness

### DIFF
--- a/.github/workflows/docker-publish-main.yml
+++ b/.github/workflows/docker-publish-main.yml
@@ -93,10 +93,15 @@ jobs:
           mkdir -p /tmp/digests
           digest="${{ steps.build-and-push.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
+      - name: sanitise arch name for artifact
+        run: |
+          clean=${{ matrix.arch }}
+          clean=${clean////-}
+          echo "ARTIFACT_NAME=digests-${clean}" >> $GITHUB_ENV
       - name: Upload digest  
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ env.ARTIFACT_NAME }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -108,7 +113,8 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: digests-*
+          merge-multiple: true
           path: /tmp/digests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
With the v4 upload_artifact action, the artifact names must be unique.  This was causing the CI to fail (see https://github.com/actions/upload-artifact/issues/478).

This PR fixes the issue by making the amd64 and arm64 artifact names unique.